### PR TITLE
Add POKEY random number generator value to save states

### DIFF
--- a/emu/pokey.h
+++ b/emu/pokey.h
@@ -52,8 +52,6 @@ extern int DELAYED_XMTDONE_IRQ;
 
 extern UBYTE POT_input[8];
 
-ULONG POKEY_GetRandomCounter(void);
-void POKEY_SetRandomCounter(ULONG value);
 UBYTE POKEY_GetByte(UWORD addr);
 void POKEY_PutByte(UWORD addr, UBYTE byte);
 void POKEY_Initialise(void);

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -58,7 +58,7 @@ static retro_audio_sample_batch_t audio_batch_cb;
 
 #define A5200_BIOS_FILE_NAME "5200.rom"
 #define A5200_BIOS_SIZE 0x800
-#define A5200_SAVE_STATE_SIZE 131357
+#define A5200_SAVE_STATE_SIZE 131361
 
 #define A5200_PALETTE_SIZE 256
 #define A5200_SCREEN_BUFFER_WIDTH 512


### PR DESCRIPTION
This PR adds the current value of the POKEY random number generator to save states. This is required for consistent operation when using runahead, netplay, etc.

It additionally ensures that the random number generator is seeded 'randomly' on all platforms (previously this only happened on Windows).