### PR TITLE
Fix calculation of 'negative' analog stick input values

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -690,8 +690,8 @@ static INLINE unsigned int a5200_get_analog_pot(int input)
       return JOY_5200_CENTER +
             (unsigned int)(((float)(joy_5200_analog_max - JOY_5200_CENTER) * amplitude) + 0.5f);
 
-   return JOY_5200_CENTER +
-         (unsigned int)(((float)(JOY_5200_CENTER - joy_5200_analog_min) * amplitude) - 0.5f);
+   return JOY_5200_CENTER -
+         (unsigned int)(((float)(JOY_5200_CENTER - joy_5200_analog_min) * -amplitude) + 0.5f);
 }
 
 static unsigned a5200_get_analog_numpad_key(int input_x, int input_y)


### PR DESCRIPTION
This PR fixes an error in the calculation of analog input values when the left RetroPad stick is pushed up or left (giving negative raw data). Unfortunately this went unnoticed due to the fact that integer wraparound on casting produced the correct result (by chance) on desktop platforms, masking the bug. But the issue became readily apparent when I tested the core on 3DS...